### PR TITLE
feat: Allow IP and Google API key configuration for run.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # DnDadventure
 One player DnD adventure using Gemini as a storyteller
+
+## Running the Application
+
+You can run the application using `run.py`. It supports the following command-line arguments:
+
+-   `--host`: Specifies the IP address the application will listen on. Defaults to `127.0.0.1`.
+-   `--google_api_key`: Specifies your Google API Key for Gemini services.
+
+Example:
+```bash
+python run.py --host 0.0.0.0 --google_api_key YOUR_API_KEY_HERE
+```

--- a/run.py
+++ b/run.py
@@ -1,4 +1,14 @@
+import argparse
+import os
 from app import create_app
+
+parser = argparse.ArgumentParser(description='Run the Flask app with configurable host and Google API Key.')
+parser.add_argument('--host', default='127.0.0.1', help='The host IP address to run the app on.')
+parser.add_argument('--google_api_key', help='Your Google API Key for Gemini.')
+args = parser.parse_args()
+
+if args.google_api_key:
+    os.environ['GEMINI_API_KEY'] = args.google_api_key
 
 app = create_app()
 
@@ -17,4 +27,4 @@ def test():
     sys.exit(1)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(host=args.host, debug=True)


### PR DESCRIPTION
I modified `run.py` to accept `--host` and `--google_api_key` command-line arguments.

- The `--host` argument allows you to specify the IP address for the Flask app to run on.
- The `--google_api_key` argument allows you to set the GEMINI_API_KEY environment variable at runtime, which is then used by the application configuration.

I also updated `README.md` to document these new arguments.

Note: Existing unit tests show failures (14 errors, 1 failed test) that appear unrelated to these changes and likely pre-exist. I've verified that the modifications to `run.py` itself work as intended for argument parsing and app execution.