### PR TITLE
feat: Populate character creation background information

### DIFF
--- a/app/data/background_data.py
+++ b/app/data/background_data.py
@@ -1,0 +1,46 @@
+# app/data/background_data.py
+
+BACKGROUND_DATA = {
+    "acolyte": {
+        "name": "Acolyte",
+        "skill_proficiencies": ["Insight", "Religion"],
+        "tool_proficiencies": [],
+        "languages": ["Two of your choice"],
+        "equipment": "A holy symbol (a gift to you when you entered the priesthood), a prayer book or prayer wheel, 5 sticks of incense, vestments, a set of common clothes, and a pouch containing 15 gp."
+    },
+    "criminal": {
+        "name": "Criminal/Spy",
+        "skill_proficiencies": ["Deception", "Stealth"],
+        "tool_proficiencies": ["One type of gaming set", "Thieves' tools"],
+        "languages": [],
+        "equipment": "A crowbar, a set of dark common clothes including a hood, and a belt pouch containing 15 gp."
+    },
+    "folk_hero": {
+        "name": "Folk Hero",
+        "skill_proficiencies": ["Animal Handling", "Survival"],
+        "tool_proficiencies": ["One type of artisan's tools", "Vehicles (land)"],
+        "languages": [],
+        "equipment": "A set of artisan's tools (one of your choice), a shovel, an iron pot, a set of common clothes, and a belt pouch containing 10 gp."
+    },
+    "noble": {
+        "name": "Noble",
+        "skill_proficiencies": ["History", "Persuasion"],
+        "tool_proficiencies": ["One type of gaming set"],
+        "languages": ["One of your choice"],
+        "equipment": "A set of fine clothes, a signet ring, a scroll of pedigree, and a purse containing 25 gp."
+    },
+    "sage": {
+        "name": "Sage",
+        "skill_proficiencies": ["Arcana", "History"],
+        "tool_proficiencies": [],
+        "languages": ["Two of your choice"],
+        "equipment": "A bottle of black ink, a quill, a small knife, a letter from a dead colleague posing a question you have not yet been able to answer, a set of common clothes, and a belt pouch containing 10 gp."
+    },
+    "soldier": {
+        "name": "Soldier",
+        "skill_proficiencies": ["Athletics", "Intimidation"],
+        "tool_proficiencies": ["One type of gaming set", "Vehicles (land)"],
+        "languages": [],
+        "equipment": "An insignia of rank, a trophy taken from a fallen enemy (a dagger, broken blade, or piece of a banner), a set of bone dice or deck of cards, a set of common clothes, and a belt pouch containing 10 gp."
+    }
+}

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -12,6 +12,7 @@ from app.utils import roll_dice, parse_coinage, ALL_SKILLS_LIST, XP_THRESHOLDS, 
 from app.gemini import geminiai, GEMINI_DM_SYSTEM_RULES
 from datetime import datetime
 from app.main import bp
+from app.data.background_data import BACKGROUND_DATA
 
 ABILITY_NAMES_FULL_SESSION_KEYS = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA']
 ABILITY_NAMES_FULL = ['Strength', 'Dexterity', 'Constitution', 'Intelligence', 'Wisdom', 'Charisma']
@@ -210,12 +211,26 @@ def creation_stats():
 def creation_background():
     if not session.get('new_character_data', {}).get('ability_scores'):
         flash('Please set ability scores first.', 'error'); return redirect(url_for('main.creation_stats'))
-    # ... (background selection logic)
+
     if request.method == 'POST':
-        # Example: session['new_character_data']['background_name'] = request.form.get('background_name')
+        selected_bg_key = request.form.get('background_name')
+        if selected_bg_key and selected_bg_key in BACKGROUND_DATA:
+            session['new_character_data']['background_key'] = selected_bg_key # Store the key
+            session['new_character_data']['background_name'] = BACKGROUND_DATA[selected_bg_key]['name']
+            session['new_character_data']['background_skill_proficiencies'] = BACKGROUND_DATA[selected_bg_key]['skill_proficiencies']
+            session['new_character_data']['background_tool_proficiencies'] = BACKGROUND_DATA[selected_bg_key]['tool_proficiencies']
+            session['new_character_data']['background_languages'] = BACKGROUND_DATA[selected_bg_key]['languages']
+            session['new_character_data']['background_equipment'] = BACKGROUND_DATA[selected_bg_key]['equipment']
+            flash(f"{BACKGROUND_DATA[selected_bg_key]['name']} background selected.", "success")
+        else:
+            flash("Please select a valid background.", "error")
+            # Re-render the page with an error if no valid background was selected
+            return render_template('create_character_background.html', backgrounds=BACKGROUND_DATA, race_name=session['new_character_data'].get('race_name'), class_name=session['new_character_data'].get('class_name'))
+
         session.modified = True
         return redirect(url_for('main.creation_skills'))
-    return render_template('create_character_background.html', backgrounds={}, race_name=session['new_character_data'].get('race_name'), class_name=session['new_character_data'].get('class_name'))
+    # GET request part
+    return render_template('create_character_background.html', backgrounds=BACKGROUND_DATA, race_name=session['new_character_data'].get('race_name'), class_name=session['new_character_data'].get('class_name'))
 
 @bp.route('/creation/skills', methods=['GET', 'POST'])
 @login_required


### PR DESCRIPTION
I've added a new data file `app/data/background_data.py` to store definitions for character backgrounds, including skill proficiencies, tool proficiencies, languages, and starting equipment.

The `creation_background` route in `app/main/routes.py` has been updated to:
- Load this background data.
- Pass it to the `create_character_background.html` template for you to see.
- Correctly store the selected background's details (including equipment) in the session when you make a selection.

This resolves an issue where the background selection page was missing information. The equipment strings now reflect the data provided, which should align with any recent weapon updates if the data is maintained accurately.