### PR TITLE
feat: Add debug div to character creation step 7

### DIFF
--- a/app/static/character_creation/step7_equipment.html
+++ b/app/static/character_creation/step7_equipment.html
@@ -1,2 +1,7 @@
 <h2>Step 7: Equipment</h2>
 <p>Equipment content will go here.</p>
+
+<div id="character-creation-debug-div" style="display: none;">
+  <h3>Debug Information</h3>
+  <pre id="character-creation-debug-data"></pre>
+</div>

--- a/app/static/js/character_creation_step7.js
+++ b/app/static/js/character_creation_step7.js
@@ -1,4 +1,46 @@
 function loadStep7Logic() {
     console.log("Step 7 JS loaded");
-    // Add logic for step 7 here
+
+    // Ensure this global variable is set by the template
+    // For example: <script>var isDebugModeEnabled = {{ config.CHARACTER_CREATION_DEBUG_MODE | tojson }};</script>
+    // Default to false if not defined, though it should be.
+    const debugModeEnabled = typeof isDebugModeEnabled !== 'undefined' ? isDebugModeEnabled : false;
+
+    const debugDiv = document.getElementById('character-creation-debug-div');
+    const debugDataPre = document.getElementById('character-creation-debug-data');
+
+    if (debugModeEnabled && debugDiv && debugDataPre) {
+        try {
+            const characterDataString = sessionStorage.getItem('characterCreationData');
+            if (characterDataString) {
+                const characterDataObject = JSON.parse(characterDataString);
+                debugDataPre.textContent = JSON.stringify(characterDataObject, null, 2);
+                debugDiv.style.display = 'block';
+            } else {
+                debugDataPre.textContent = 'characterCreationData not found in session storage.';
+                debugDiv.style.display = 'block'; // Show div to indicate missing data
+            }
+        } catch (error) {
+            console.error('Error processing character creation debug data:', error);
+            debugDataPre.textContent = 'Error loading debug data. Check console for details.';
+            debugDiv.style.display = 'block'; // Show div to indicate error
+        }
+    } else if (debugDiv) {
+        debugDiv.style.display = 'none';
+    }
 }
+
+// Since the character creation steps are loaded dynamically,
+// ensure loadStep7Logic is called when the step becomes active.
+// This might be handled by a central navigation script.
+// If this script is loaded specifically for step 7 (e.g. via a script tag in step7_equipment.html),
+// then calling it directly might be appropriate.
+// For now, assuming it's called correctly by the existing infrastructure.
+// If characterCreationData might not be immediately available, consider using DOMContentLoaded or similar.
+// However, sessionStorage should be available immediately.
+
+// If this script is loaded *after* the DOM is ready (e.g. end of body in step7_equipment.html)
+// then it can be called directly.
+// Otherwise, wrap it in an event listener:
+// document.addEventListener('DOMContentLoaded', loadStep7Logic);
+// For now, let's assume it's called by the existing character creation script runner.

--- a/app/templates/character_creation_wizard.html
+++ b/app/templates/character_creation_wizard.html
@@ -65,6 +65,9 @@
     </div>
 </div>
 
+<script>
+    var isDebugModeEnabled = {{ config.CHARACTER_CREATION_DEBUG_MODE | default(false) | tojson }};
+</script>
 <script src="{{ url_for('static', filename='js/general.js') }}"></script>
 <script src="{{ url_for('static', filename='js/character_creation_step0.js') }}"></script>
 <script src="{{ url_for('static', filename='js/character_creation.js') }}"></script>


### PR DESCRIPTION
Implements a debug information section on Step 7 of the character creation wizard ('Equipment').

This section displays the content of the `characterCreationData` object from session storage in a prettified JSON format.

The visibility of this debug div is controlled by a new 'Character Creation Debug Mode' checkbox in the Admin General Settings.

Changes include:
- Added a div with id `character-creation-debug-div` to `app/static/character_creation/step7_equipment.html`.
- Updated `app/static/js/character_creation_step7.js` to fetch `characterCreationData` from session storage and display it if debug mode is enabled.
- Modified `app/templates/character_creation_wizard.html` to pass the `CHARACTER_CREATION_DEBUG_MODE` Flask config setting to client-side JavaScript via a global variable `isDebugModeEnabled`.