### PR TITLE
Add admin user functionality and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg-info/
+dist/
+build/
+*.egg
+venv/
+env/
+develop-eggs/
+sdist/
+var/
+*.log
+*.pot
+
+# Flask specific
+instance/config.py
+instance/*.db # If you store SQLite DBs in instance folder and don't want to track them
+*.sqlite
+*.sqlite3
+
+# Secrets
+.env
+secrets.py
+
+# IDE / Editor specific
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This project implements a Flask-based web application with Google OAuth for user
                 *   `DB_PASSWORD`: Database password.
                 *   `DB_NAME`: Database name.
             *   `SECRET_KEY`: A long, random string used to secure sessions. Generate a strong one for production.
+            *   `ADMIN_EMAIL` (Optional): Set this to the email address of a user who should automatically be granted administrator privileges upon login. If a user logs in with this email, their `is_admin` flag will be set to `True`.
 
 5.  **Set up Google OAuth 2.0 Credentials:**
     *   Go to the [Google Cloud Console](https://console.cloud.google.com/).

--- a/instance/config.py.example
+++ b/instance/config.py.example
@@ -25,3 +25,8 @@ DB_NAME = "your_db_name"
 
 # Flask App Secret Key (generate a random one for your actual config.py)
 SECRET_KEY = "your_very_secret_key_here"
+
+# Admin Configuration
+# Set this to the email address of the user who should be granted admin privileges.
+# If a user logs in with this email, they will be marked as an administrator.
+ADMIN_EMAIL = "your_admin_email@example.com"

--- a/templates/index.html
+++ b/templates/index.html
@@ -104,7 +104,9 @@
 
     <div class="tab-container">
         <button class="tab-button active" onclick="openTab(event, 'Home')">Home</button>
+        {% if current_user.is_authenticated and current_user.is_admin %}
         <button class="tab-button" onclick="openTab(event, 'Admin')">Admin</button>
+        {% endif %}
     </div>
 
     <div class="tab-content-area">
@@ -117,6 +119,7 @@
                         <p><strong>Name:</strong> {{ current_user.name }}</p>
                         <p><strong>Email:</strong> {{ current_user.email }}</p>
                         <p><strong>Google ID:</strong> {{ current_user.google_id }}</p>
+                        <p><strong>Admin Status:</strong> {{ "Yes" if current_user.is_admin else "No" }}</p>
                     </div>
                     <a href="{{ url_for('logout') }}" class="logout-button">Logout</a>
                 {% else %}
@@ -126,12 +129,15 @@
             </div>
         </div>
 
+        {% if current_user.is_authenticated and current_user.is_admin %}
         <div id="Admin" class="tab-pane">
             <div class="home-content-container"> <!-- Using similar container for consistency -->
                 <h2>Admin Section</h2>
                 <p>This is the placeholder for Admin content.</p>
+                <p>Welcome, Admin User! You have access to administrative functions.</p>
             </div>
         </div>
+        {% endif %}
     </div>
 
     <script>


### PR DESCRIPTION
- Added `is_admin` field to User model.
- Added `ADMIN_EMAIL` to `config.py.example` to specify an admin user.
- Login logic now checks `ADMIN_EMAIL` to grant admin rights.
- Updated `index.html` to conditionally display admin tab and info.
- Created `.gitignore` with common Python/Flask ignores including `instance/config.py`.
- Updated README to document `ADMIN_EMAIL`.