### PR TITLE
feat: Change chat window background to light gray

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -12,6 +12,7 @@ body {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+    background-color: #f8f8f8;
 }
 
 #messages {


### PR DESCRIPTION
This change sets the background color of the chat window to a very light gray (#f8f8f8). This helps the individual messages stand out more clearly.