### PR TITLE
feat: Add floating character sheet

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -381,3 +381,47 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+#character-sheet-button {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
+    z-index: 2;
+}
+
+#character-sheet-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+    z-index: 3;
+    display: none; /* Hidden by default */
+}
+
+#character-sheet {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80%;
+    max-width: 800px;
+    height: 90%;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 5px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.5);
+    overflow-y: auto;
+}
+
+#close-character-sheet {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    cursor: pointer;
+    color: red;
+    font-size: 20px;
+    font-weight: bold;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,15 @@
             <a href="/admin">Admin</a>
         {% endif %}
     </div>
+    <div id="character-sheet-button">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-file-text"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+    </div>
+    <div id="character-sheet-overlay">
+        <div id="character-sheet">
+            <div id="close-character-sheet">X</div>
+            <!-- Character sheet content goes here -->
+        </div>
+    </div>
     <div id="app">
         <div id="chat-window">
             <div id="messages"></div>
@@ -344,6 +353,14 @@
             if (newCharId) {
                 selectCharacter(null, newCharId);
             }
+        };
+
+        document.getElementById('character-sheet-button').onclick = function() {
+            document.getElementById('character-sheet-overlay').style.display = 'block';
+        };
+
+        document.getElementById('close-character-sheet').onclick = function() {
+            document.getElementById('character-sheet-overlay').style.display = 'none';
         };
     </script>
 </body>


### PR DESCRIPTION
This commit introduces a new feature: a floating character sheet accessible from the main chat page.

Key changes:
- A floating button with a character sheet icon has been added to the top right of the screen.
- Clicking the button opens a character sheet overlay.
- The overlay can be closed by clicking the red 'X' in the top right corner.
- The implementation includes HTML, CSS, and JavaScript changes.